### PR TITLE
Update CSS import path in Highlighted.svelte

### DIFF
--- a/src/lib/ui/Highlighted.svelte
+++ b/src/lib/ui/Highlighted.svelte
@@ -4,7 +4,7 @@
 -->
 
 <script lang="ts">
-	import '$lib/reset.css';
+	import '../reset.css';
 	import hljs, { type HighlightResult } from 'highlight.js';
 	import { onMount } from 'svelte';
 	import { Language } from '$lib/scripts/language.js';


### PR DESCRIPTION
The import path for the 'reset.css' file in Highlighted.svelte has been updated to a relative path instead of the previous absolute path. This is to improve reliability and readability of the code.