### PR TITLE
Update CSS in HighlightedLine.svelte

### DIFF
--- a/src/lib/ui/HighlightedLine.svelte
+++ b/src/lib/ui/HighlightedLine.svelte
@@ -54,5 +54,99 @@
 			user-select: text;
 			-webkit-user-select: text;
 		}
+
+		/***
+		The new CSS reset - version 1.11.2 (last updated 15.11.2023)
+		GitHub page: https://github.com/elad2412/the-new-css-reset
+***/
+
+		/*
+					Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property
+					- The "symbol *" part is to solve Firefox SVG sprite bug
+					- The "html" element is excluded, otherwise a bug in Chrome breaks the CSS hyphens property (https://github.com/elad2412/the-new-css-reset/issues/36)
+			 */
+		& *:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
+			all: unset;
+			display: revert;
+		}
+
+		/* Preferred box-sizing value */
+		& *,
+		*::before,
+		*::after {
+			box-sizing: border-box;
+		}
+
+		/* Reapply the pointer cursor for anchor tags */
+		& a,
+		button {
+			cursor: revert;
+		}
+
+		/* Remove list styles (bullets/numbers) */
+		& ol,
+		ul,
+		menu,
+		summary {
+			list-style: none;
+		}
+
+		/* For images to not be able to exceed their container */
+		& img {
+			max-inline-size: 100%;
+			max-block-size: 100%;
+		}
+
+		/* removes spacing between cells in tables */
+		& table {
+			border-collapse: collapse;
+		}
+
+		/* revert the 'white-space' property for textarea elements on Safari */
+		& textarea {
+			white-space: revert;
+		}
+
+		/* minimum style to allow to style meter element */
+		& meter {
+			-webkit-appearance: revert;
+			appearance: revert;
+		}
+
+		/* preformatted text - use only for this feature */
+		& :where(pre) {
+			all: revert;
+			box-sizing: border-box;
+		}
+
+		/* reset default text opacity of input placeholder */
+		& ::placeholder {
+			color: unset;
+		}
+
+		/* fix the feature of 'hidden' attribute.
+				 display:revert; revert to element instead of attribute */
+		& :where([hidden]) {
+			display: none;
+		}
+
+		/* revert for bug in Chromium browsers
+				 - fix for the content editable attribute will work properly.
+				 - webkit-user-select: auto; added for Safari in case of using user-select:none on wrapper element*/
+		& :where([contenteditable]:not([contenteditable='false'])) {
+			-moz-user-modify: read-write;
+			-webkit-user-modify: read-write;
+			overflow-wrap: break-word;
+		}
+
+		/* apply back the draggable feature - exist only in Chromium and Safari */
+		& :where([draggable='true']) {
+			-webkit-user-drag: element;
+		}
+
+		/* Remove details summary webkit styles */
+		& ::-webkit-details-marker {
+			display: none;
+		}
 	}
 </style>


### PR DESCRIPTION
Added the new CSS reset version 1.11.2 to the HighlightedLine.svelte file. The updated CSS helps to handle the styles of User-Agent-Stylesheet, box-sizing value, reapply pointer cursor for anchor tags, removes list styles and other elements effectively.