### PR TITLE
Update Header.svelte to use base path

### DIFF
--- a/src/sample/header/Header.svelte
+++ b/src/sample/header/Header.svelte
@@ -1,9 +1,12 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+</script>
 <header translate="no">
 	<h1>Svelte Diff Highlighting</h1>
 	<nav>
-		<a href="/">Docs</a>
-		<a href="/api">API</a>
-		<a href="/example">Examples</a>
+		<a href="{base}/">Docs</a>
+		<a href="{base}/api">API</a>
+		<a href="{base}/example">Examples</a>
 	</nav>
 </header>
 


### PR DESCRIPTION
The Header.svelte file is updated to utilize the base path when generating URLs for 'Docs', 'API', and 'Examples'. This improves the application's flexibility, as it can now be served from any base URL, not just the root.